### PR TITLE
Renamed method parameter and removed some unused parameters to clarify the code.

### DIFF
--- a/lib/VippyConfig.js
+++ b/lib/VippyConfig.js
@@ -171,9 +171,9 @@ VippyConfig.prototype.stale = function() {
   return this._config.stale || 3;
 };
 
-VippyConfig.prototype.active = function(v, method) {
+VippyConfig.prototype.active = function(v, reason) {
   if(v !== undefined)
-    this._active[method || 'administrative'] = v;
+    this._active[reason || 'administrative'] = v;
   if(!this.mature()) return false;
   for(var m in this._active) {
     if(this._active[m] === false) return false;
@@ -181,7 +181,7 @@ VippyConfig.prototype.active = function(v, method) {
   return true;
 };
 
-VippyConfig.prototype.inactive_reason = function(v, method) {
+VippyConfig.prototype.inactive_reason = function() {
   if(!this.mature()) return 'booting';
   for(var m in this._active) {
     if(this._active[m] === false) return m;


### PR DESCRIPTION
The second parameter to the VippyConfig.prototype.active was named
'method' when in fact is it just a text string passed and used as the
'reason' for becoming inactive in the
VippyConfig.prototype.inactive_reason function.

This change renames the parameter to 'reason' to make the code easier to
understand.

Additionally, the prototype for the VippyConfig.prototype.inactive_reason function
included two parameters (v, method) which were unused.

This change removed the extra parameters.
