### PR TITLE
added privilege sys_ip_config to manifest and fixed typo

### DIFF
--- a/smf/vippy-svc
+++ b/smf/vippy-svc
@@ -1,9 +1,9 @@
 #!/bin/sh
 #
 # Instructions:
-# 1. place this script to /opt/local/sbin
+# 1. copy this script into /opt/local/sbin
 # 2. copy vippy.xml to /var/svc/manifest/network/ha/vippy.xml
-# 3. import the manifest with svccs import /var/svc/manifest/network/ha/vippy.xml
+# 3. import the manifest with svccfg import /var/svc/manifest/network/ha/vippy.xml
 #
 # Optionally if required the nodename can be specified via /opt/local/etc/vippy.node
 

--- a/smf/vippy.xml
+++ b/smf/vippy.xml
@@ -18,7 +18,7 @@
                 <method_credential
                     user="root"
                     group="root"
-                    privileges="BASIC,PRIV_NET_PRIVADDR" />
+                    privileges="basic,net_privaddr,sys_ip_config" />
             </method_context>
         </exec_method>
         <exec_method


### PR DESCRIPTION
Fixed SMF manifest as VIP fails to configure on nodes without privilege "sys_ip_config". This is now working fine, tested with multiple nodes.