### PR TITLE
Fix bug for explodeIPs for greater than /24 range

### DIFF
--- a/lib/VippyNetwork.js
+++ b/lib/VippyNetwork.js
@@ -115,7 +115,7 @@ var explodeIPs = function(start, end) {
     for (var i=3; i>0; i--) {
       if(a[i] > 255) {
         a[i]=0;
-        a[i-i]++;
+        a[i-1]++;
       }
     }
   }


### PR DESCRIPTION
This should return 512 results not 256.
explodeIPs("10.90.2.0","10.90.3.255")